### PR TITLE
Add Cobertura Reporting to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
                     <skipEmptyReport>false</skipEmptyReport>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
+            </plugin>
         </plugins>
     </reporting>
     <dependencies>


### PR DESCRIPTION
Adds the Cobertura plug-in to the reporting section of the pom.xml
This ensures that the mvn site generates a Cobertura report.