### PR TITLE
Adds the update loop over all walls

### DIFF
--- a/src/main/java/nl/tudelft/model/Level.java
+++ b/src/main/java/nl/tudelft/model/Level.java
@@ -68,6 +68,9 @@ public class Level implements Updateable, Renderable, Modifiable {
         for (GameObject gameObject : pickups) {
             gameObject.update(this, delta);
         }
+        for (GameObject gameObject: walls) {
+            gameObject.update(this, delta);
+        }
         
         // Update the object lists.
         for (GameObject obj : toAdd) {


### PR DESCRIPTION
Walls are not generally updated, but they are updateable and therefore
should be called.

Without this, the Level object will never update its walls.

> bug