### PR TITLE
Calls reset() on all players on next level

### DIFF
--- a/src/main/java/nl/tudelft/model/Game.java
+++ b/src/main/java/nl/tudelft/model/Game.java
@@ -178,15 +178,22 @@ public class Game implements Renderable, Modifiable {
         }
         return result;
     }
+    
+    /**
+     * Calls {@link Player#reset()} on all players in the game.
+     */
+    private void resetPlayers() {
+        for (Player player : players) {
+            player.reset();
+        }
+    }
 
     /**
      * Resets the current level if the players have lives left, ends the game if they do not.
      */
     public void levelReset() {
         if (getPlayerLives() > 0) {
-            for (Player player : players) {
-                player.reset();
-            }
+            resetPlayers();
             setCurLevel(levelFact.getLevel(getCurLevel().getID()));
         } else {
             gameOver();
@@ -199,6 +206,7 @@ public class Game implements Renderable, Modifiable {
      */
     public void nextLevel() {
         if (levelIt.hasNext()) {
+            resetPlayers();
             setCurLevel(levelIt.next());
         } else {
             gameCompleted();


### PR DESCRIPTION
This prevents players from carrying over weapons and power-ups.

> bugfix