### PR TITLE
Fix main and Critical pmd violations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,7 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+
+
+### PMD ###
+.pmd

--- a/src/main/java/nl/tudelft/model/Bubble.java
+++ b/src/main/java/nl/tudelft/model/Bubble.java
@@ -19,14 +19,14 @@ import org.newdawn.slick.geom.Shape;
  */
 public class Bubble extends GameObject {
 
-    private float gravity = 0.1f;
+    private static final float GRAVITY = 0.1f;
     private float verticalSpeed = 0.0f;
     private float horizontalSpeed = 2.0f;
     private boolean isHit = false;
     private float maxVerticalSpeed;
     private int size;
     private boolean slowBalls = false;
-    private boolean freeze = false;
+    private boolean frozen = false;
     private int tickCount = 0;
 
     /**
@@ -126,7 +126,7 @@ public class Bubble extends GameObject {
      */
     @Override
     public <T extends Modifiable> void update(T container, int delta) throws SlickException {
-        if ((!slowBalls || tickCount % 2 == 0) && !freeze) {
+        if ((!slowBalls || tickCount % 2 == 0) && !frozen) {
             move();
         }
 
@@ -194,7 +194,7 @@ public class Bubble extends GameObject {
 
         setLocX(newX);
         setLocY(newY);
-        verticalSpeed -= gravity;
+        verticalSpeed -= GRAVITY;
     }
 
     public void slowBubbleDown(boolean slowDown) {
@@ -202,7 +202,7 @@ public class Bubble extends GameObject {
     }
 
     public void freeze(boolean freeze) {
-        this.freeze = freeze;
+        this.frozen = freeze;
     }
 
     public void setIsHit() {

--- a/src/main/java/nl/tudelft/model/Game.java
+++ b/src/main/java/nl/tudelft/model/Game.java
@@ -23,11 +23,11 @@ import org.newdawn.slick.state.StateBasedGame;
 
 public class Game implements Renderable, Modifiable {
 
-    public static final Logger logger;
+    public static final Logger LOGGER;
 
     static {
         try {
-            logger = new DefaultLogger();
+            LOGGER = new DefaultLogger();
         } catch (IOException e) {
             throw new IllegalStateException("This shouldn't happen", e);
         }
@@ -37,12 +37,12 @@ public class Game implements Renderable, Modifiable {
     private final int containerHeight;
     private final LinkedList<Level> levels;
     private final Iterator<Level> levelIt;
-    private LinkedList<Player> players;
-    private LinkedList<Player> playerToDelete = new LinkedList<>();
+    private final LinkedList<Player> players;
+    private final LinkedList<Player> playerToDelete = new LinkedList<>();
     private Level curLevel;
     private final CollisionHandler<GameObject, GameObject> collisionHandler;
     private final LevelFactory levelFact;
-    private QuadTree quad = new QuadTree(0, new Rectangle(0, 0, 1200, 800));
+    private final QuadTree quad = new QuadTree(0, new Rectangle(0, 0, 1200, 800));
     private final StateBasedGame mainApp;
 
     /**
@@ -62,7 +62,7 @@ public class Game implements Renderable, Modifiable {
      */
     public Game(StateBasedGame mainApp, LinkedList<Player> players, int containerWidth,
             int containerHeight) throws IllegalArgumentException {
-        logger.log(VERBOSE, "Game", "constructor called");
+        LOGGER.log(VERBOSE, "Game", "constructor called");
         this.mainApp = mainApp;
         this.containerWidth = containerWidth;
         this.containerHeight = containerHeight;
@@ -275,7 +275,7 @@ public class Game implements Renderable, Modifiable {
      * 
      * @return the CollisionHandler that will be used.
      */
-    protected CollisionHandler<GameObject, GameObject> getNewCollisionHandler() {
+    protected final CollisionHandler<GameObject, GameObject> getNewCollisionHandler() {
         return new DefaultCollisionHandler();
     }
 

--- a/src/main/java/nl/tudelft/model/Level.java
+++ b/src/main/java/nl/tudelft/model/Level.java
@@ -21,16 +21,16 @@ public class Level implements Updateable, Renderable, Modifiable {
     private final LinkedList<Bubble> bubbles;
     private final LinkedList<GameObject> pendingRemoval = new LinkedList<>();
     private final LinkedList<GameObject> pendingAddition = new LinkedList<>();
-    private final static int EXTRA_TIME = 20000;
+    private static final int EXTRA_TIME = 20000;
     private int time;
     private final int maxTime;
     private double speed;
     private int utilSlowCounter = 0;
     private boolean slowBalls = false;
-    private final static int UTIL_SLOWDOWN_TIME = 300;
+    private static final int UTIL_SLOWDOWN_TIME = 300;
     private int utilFreezeCounter = 0;
     private boolean frozenBalls = false;
-    private final static int UTIL_FREEZE_TIME = 300;
+    private static final int UTIL_FREEZE_TIME = 300;
 
     private final int id;
 
@@ -122,8 +122,8 @@ public class Level implements Updateable, Renderable, Modifiable {
 
     private void setSlowBalls() {
         utilSlowCounter =
-                (utilSlowCounter <= UTIL_SLOWDOWN_TIME && utilSlowCounter != 0) ? utilSlowCounter + 1
-                        : 0;
+                (utilSlowCounter <= UTIL_SLOWDOWN_TIME && utilSlowCounter != 0)
+                        ? utilSlowCounter + 1 : 0;
         if (slowBalls) {
             for (Bubble bubble : bubbles) {
                 bubble.slowBubbleDown(true);

--- a/src/main/java/nl/tudelft/model/Level.java
+++ b/src/main/java/nl/tudelft/model/Level.java
@@ -15,24 +15,24 @@ import org.newdawn.slick.SlickException;
 
 public class Level implements Updateable, Renderable, Modifiable {
 
-    private LinkedList<Wall> walls;
-    private LinkedList<Projectile> projectiles;
-    private LinkedList<Pickup> pickups;
-    private LinkedList<Bubble> bubbles;
-    private LinkedList<GameObject> toRemove = new LinkedList<>();
-    private LinkedList<GameObject> toAdd = new LinkedList<>();
-    private final int extraTime = 20000;
+    private final LinkedList<Wall> walls;
+    private final LinkedList<Projectile> projectiles;
+    private final LinkedList<Pickup> pickups;
+    private final LinkedList<Bubble> bubbles;
+    private final LinkedList<GameObject> pendingRemoval = new LinkedList<>();
+    private final LinkedList<GameObject> pendingAddition = new LinkedList<>();
+    private final static int EXTRA_TIME = 20000;
     private int time;
     private final int maxTime;
     private double speed;
     private int utilSlowCounter = 0;
     private boolean slowBalls = false;
-    private final int utilSlowdownTime = 300;
+    private final static int UTIL_SLOWDOWN_TIME = 300;
     private int utilFreezeCounter = 0;
     private boolean frozenBalls = false;
-    private final int utilFreezeTime = 300;
+    private final static int UTIL_FREEZE_TIME = 300;
 
-    private int id;
+    private final int id;
 
     /**
      * Creates a level object with an object list, a timer and a speed.
@@ -81,7 +81,7 @@ public class Level implements Updateable, Renderable, Modifiable {
         }
 
         // Update the object lists.
-        for (GameObject obj : toAdd) {
+        for (GameObject obj : pendingAddition) {
             if (obj instanceof Projectile) {
                 projectiles.add((Projectile) obj);
             }
@@ -96,7 +96,7 @@ public class Level implements Updateable, Renderable, Modifiable {
             }
         }
 
-        for (GameObject obj : toRemove) {
+        for (GameObject obj : pendingRemoval) {
             if (obj instanceof Projectile) {
                 projectiles.remove(obj);
             }
@@ -111,25 +111,25 @@ public class Level implements Updateable, Renderable, Modifiable {
             }
         }
 
-        toAdd.clear();
-        toRemove.clear();
+        pendingAddition.clear();
+        pendingRemoval.clear();
 
         time -= delta;
 
-        slowBalls();
+        setSlowBalls();
         freezeBalls();
     }
 
-    private void slowBalls() {
+    private void setSlowBalls() {
         utilSlowCounter =
-                (utilSlowCounter <= utilSlowdownTime && utilSlowCounter != 0) ? utilSlowCounter + 1
+                (utilSlowCounter <= UTIL_SLOWDOWN_TIME && utilSlowCounter != 0) ? utilSlowCounter + 1
                         : 0;
         if (slowBalls) {
             for (Bubble bubble : bubbles) {
                 bubble.slowBubbleDown(true);
             }
         }
-        if (utilSlowCounter == utilSlowdownTime) {
+        if (utilSlowCounter == UTIL_SLOWDOWN_TIME) {
             slowBalls = false;
             for (Bubble bubble : bubbles) {
                 bubble.slowBubbleDown(false);
@@ -139,14 +139,14 @@ public class Level implements Updateable, Renderable, Modifiable {
 
     private void freezeBalls() {
         utilFreezeCounter =
-                (utilFreezeCounter <= utilFreezeTime && utilFreezeCounter != 0)
+                (utilFreezeCounter <= UTIL_FREEZE_TIME && utilFreezeCounter != 0)
                         ? utilFreezeCounter + 1 : 0;
         if (frozenBalls) {
             for (Bubble bubble : bubbles) {
                 bubble.freeze(true);
             }
         }
-        if (utilFreezeCounter == utilFreezeTime) {
+        if (utilFreezeCounter == UTIL_FREEZE_TIME) {
             frozenBalls = false;
             for (Bubble bubble : bubbles) {
                 bubble.freeze(false);
@@ -177,7 +177,7 @@ public class Level implements Updateable, Renderable, Modifiable {
 
     @Override
     public void toAdd(GameObject obj) {
-        toAdd.add(obj);
+        pendingAddition.add(obj);
         // if (obj instanceof Projectile) {
         // projectiles.add((Projectile)obj);
         // return projectiles.contains(obj);
@@ -195,7 +195,7 @@ public class Level implements Updateable, Renderable, Modifiable {
 
     @Override
     public void toRemove(GameObject obj) {
-        toRemove.add(obj);
+        pendingRemoval.add(obj);
         // if (obj instanceof Projectile) {
         // projectiles.remove(obj);
         // return !projectiles.contains(obj);
@@ -238,7 +238,7 @@ public class Level implements Updateable, Renderable, Modifiable {
                 splitAllBubbles(bubbles, false);
                 break;
             case TIME:
-                time = (time + extraTime < maxTime) ? time + extraTime : maxTime;
+                time = (time + EXTRA_TIME < maxTime) ? time + EXTRA_TIME : maxTime;
                 break;
             default:
                 throw new IllegalArgumentException();
@@ -317,10 +317,10 @@ public class Level implements Updateable, Renderable, Modifiable {
     }
 
     public LinkedList<GameObject> getToRemove() {
-        return toRemove;
+        return pendingRemoval;
     }
 
     public LinkedList<GameObject> getToAdd() {
-        return toAdd;
+        return pendingAddition;
     }
 }

--- a/src/main/java/nl/tudelft/model/LevelFactory.java
+++ b/src/main/java/nl/tudelft/model/LevelFactory.java
@@ -8,7 +8,7 @@ import nl.tudelft.semgroup4.Resources;
 public class LevelFactory {
 
     private final Game game;
-    private final static int LEVEL_COUNT = 4;
+    private static final int LEVEL_COUNT = 4;
 
     public LevelFactory(Game game) {
         this.game = game;

--- a/src/main/java/nl/tudelft/model/LevelFactory.java
+++ b/src/main/java/nl/tudelft/model/LevelFactory.java
@@ -7,8 +7,8 @@ import nl.tudelft.semgroup4.Resources;
 
 public class LevelFactory {
 
-    private Game game;
-    private int levelCount = 4;
+    private final Game game;
+    private final static int LEVEL_COUNT = 4;
 
     public LevelFactory(Game game) {
         this.game = game;
@@ -26,7 +26,7 @@ public class LevelFactory {
     public LinkedList<Level> getAllLevels() {
         LinkedList<Level> result = new LinkedList<>();
 
-        for (int i = 1; i <= levelCount; i++) {
+        for (int i = 1; i <= LEVEL_COUNT; i++) {
             result.add(getLevel(i));
         }
         return result;

--- a/src/main/java/nl/tudelft/model/Player.java
+++ b/src/main/java/nl/tudelft/model/Player.java
@@ -31,13 +31,13 @@ public class Player extends GameObject {
     private int removingShieldCounter = 0;
     private int invincibilityCounter = 0;
     private int speedupCounter = 0;
-    private boolean isFirstPlayer;
-    private boolean hasSpeedup = false;
+    private final boolean firstPlayer;
+    private boolean speedup = false;
     private final Input input;
 
     private Weapon weapon;
 
-    private LinkedList<Powerup> powerups;
+    private final LinkedList<Powerup> powerups;
     private Animation animationCurrent;
     private final Animation animationLeft;
     private final Animation animationRight;
@@ -58,7 +58,7 @@ public class Player extends GameObject {
         super(Resources.playerImageStill.copy(), locX, locY);
         powerups = new LinkedList<>();
         speed = 4;
-        this.isFirstPlayer = isFirstPlayer;
+        this.firstPlayer = isFirstPlayer;
 
         this.input = input;
         this.weapon = new Weapon(Resources.weaponImageRegular.copy(), Pickup.WeaponType.REGULAR);
@@ -105,18 +105,18 @@ public class Player extends GameObject {
             container.toRemove(this);
         }
 
-        if ((input.isKeyDown(Input.KEY_LEFT) && isFirstPlayer)
-                || (input.isKeyDown(Input.KEY_A) && !isFirstPlayer)) {
+        if ((input.isKeyDown(Input.KEY_LEFT) && firstPlayer)
+                || (input.isKeyDown(Input.KEY_A) && !firstPlayer)) {
             setAnimationCurrent(animationLeft);
             setLocX(locX - speed);
         }
-        if ((input.isKeyDown(Input.KEY_RIGHT) && isFirstPlayer)
-                || (input.isKeyDown(Input.KEY_D) && !isFirstPlayer)) {
+        if ((input.isKeyDown(Input.KEY_RIGHT) && firstPlayer)
+                || (input.isKeyDown(Input.KEY_D) && !firstPlayer)) {
             setAnimationCurrent(animationRight);
             setLocX(locX + speed);
         }
-        if ((input.isKeyDown(Input.KEY_SPACE) && isFirstPlayer)
-                || (input.isKeyDown(Input.KEY_W) && !isFirstPlayer)) {
+        if ((input.isKeyDown(Input.KEY_SPACE) && firstPlayer)
+                || (input.isKeyDown(Input.KEY_W) && !firstPlayer)) {
             if (fireCounter == 0) {
                 fireCounter++;
                 weapon.fire(container, (int) this.locX, (int) this.locY, this.getWidth(),
@@ -124,9 +124,9 @@ public class Player extends GameObject {
             }
         }
         if ((!(input.isKeyDown(Input.KEY_LEFT)
-                || input.isKeyDown(Input.KEY_RIGHT)) && isFirstPlayer)
+                || input.isKeyDown(Input.KEY_RIGHT)) && firstPlayer)
                 || (!(input.isKeyDown(Input.KEY_A)
-                || input.isKeyDown(Input.KEY_D)) && !isFirstPlayer)) {
+                || input.isKeyDown(Input.KEY_D)) && !firstPlayer)) {
             setAnimationCurrent(null);
         }
 
@@ -178,7 +178,7 @@ public class Player extends GameObject {
     public void removeSpeedup() {
         speed = REGULAR_SPEED;
         speedupCounter = 0;
-        hasSpeedup = false;
+        speedup = false;
     }
 
     /**
@@ -225,9 +225,9 @@ public class Player extends GameObject {
                 break;
             case SPEEDUP:
                 speedupCounter = 1;
-                if (!hasSpeedup) {
+                if (!speedup) {
                     speed = SPEEDUP * speed;
-                    hasSpeedup = true;
+                    speedup = true;
                 }
                 break;
             case POINTS:
@@ -341,7 +341,7 @@ public class Player extends GameObject {
      * @return true if he is player 1.
      */
     public boolean isFirstPlayer() {
-        return this.isFirstPlayer;
+        return this.firstPlayer;
     }
     /**
      * returns the powerups of the player.

--- a/src/main/java/nl/tudelft/model/Player.java
+++ b/src/main/java/nl/tudelft/model/Player.java
@@ -86,7 +86,7 @@ public class Player extends GameObject {
         } else if (isInvincible()) {
             if ((invincibilityCounter > 540 && invincibilityCounter % 2 == 0)
                     || invincibilityCounter < 540) {
-                graphics.drawImage(Resources.power_invincible, getLocX(), getLocY());
+                graphics.drawImage(Resources.powerInvincible, getLocX(), getLocY());
             }
         }
         graphics.setColor(Color.green);

--- a/src/main/java/nl/tudelft/model/Projectile.java
+++ b/src/main/java/nl/tudelft/model/Projectile.java
@@ -12,9 +12,9 @@ import org.newdawn.slick.geom.Shape;
 
 public class Projectile extends GameObject {
 
-    private int speed;
+    private final int speed;
     private int width;
-    private Weapon wp;
+    private final Weapon weapon;
     private boolean hitBubble;
     private int tickCount;
     private boolean hitWall;
@@ -49,7 +49,7 @@ public class Projectile extends GameObject {
         this.speed = speed;
         this.playerWidth = playerWidth;
         this.playerHeight = playerHeight;
-        this.wp = wp;
+        this.weapon = wp;
         hitBubble = false;
         hitWall = false;
         tickCount = 0;
@@ -72,12 +72,12 @@ public class Projectile extends GameObject {
     public <T extends Modifiable> void reset(T container) {
         Resources.weaponFire.stop();
         // Set every variable to the starting variables
-        if (!wp.isSticky() || hitBubble) {
-            wp.remove(container, this);
+        if (!weapon.isSticky() || hitBubble) {
+            weapon.remove(container, this);
         } else if (tickCount == 0) {
             tickCount++;
         } else if (tickCount == 90) {
-            wp.remove(container, this);
+            weapon.remove(container, this);
             tickCount = 0;
         }
 
@@ -91,7 +91,7 @@ public class Projectile extends GameObject {
         hitBubble = true;
     }
 
-    public boolean getHitBubble() {
+    public boolean isHitBubble() {
         return hitBubble;
     }
 
@@ -149,6 +149,6 @@ public class Projectile extends GameObject {
     }
 
     public Weapon getWeapon() {
-        return this.wp;
+        return this.weapon;
     }
 }

--- a/src/main/java/nl/tudelft/model/Wall.java
+++ b/src/main/java/nl/tudelft/model/Wall.java
@@ -13,7 +13,7 @@ public class Wall extends GameObject {
 
     @Override
     public <T extends Modifiable> void update(T container, int delta) throws SlickException {
-
+        // Walls do not do anything in their update as of yet.
     }
 
 }

--- a/src/main/java/nl/tudelft/model/Weapon.java
+++ b/src/main/java/nl/tudelft/model/Weapon.java
@@ -14,7 +14,7 @@ public class Weapon extends PickupContent {
     private final ArrayList<Projectile> projectiles;
     private final Image img;
     private final WeaponType type;
-    private boolean sticky;
+    private final boolean sticky;
     private final int maxCount;
 
     /**
@@ -29,14 +29,15 @@ public class Weapon extends PickupContent {
      */
     public Weapon(Image image, WeaponType type) throws IllegalArgumentException {
         this.type = type;
-        sticky = false;
 
         switch (type) {
             case REGULAR:
                 maxCount = 1;
+                sticky = false;
                 break;
             case DOUBLE:
                 maxCount = 2;
+                sticky = false;
                 break;
             case STICKY:
                 maxCount = 1;
@@ -44,6 +45,7 @@ public class Weapon extends PickupContent {
                 break;
             case FLOWER:
                 maxCount = 10;
+                sticky = false;
                 break;
             default:
                 throw new IllegalArgumentException();

--- a/src/main/java/nl/tudelft/model/Weapon.java
+++ b/src/main/java/nl/tudelft/model/Weapon.java
@@ -11,11 +11,11 @@ import org.newdawn.slick.Image;
 public class Weapon extends PickupContent {
 
     private Player player;
-    private ArrayList<Projectile> projectiles;
-    private Image img;
-    private WeaponType type;
+    private final ArrayList<Projectile> projectiles;
+    private final Image img;
+    private final WeaponType type;
     private boolean sticky;
-    private int maxCount;
+    private final int maxCount;
 
     /**
      * Creates a new Weapon of the given type and with the given image.

--- a/src/main/java/nl/tudelft/model/pickups/Pickup.java
+++ b/src/main/java/nl/tudelft/model/pickups/Pickup.java
@@ -38,22 +38,22 @@ public class Pickup extends GameObject {
             // regular weapon
                 case 1:
                     content = new Weapon(Resources.weaponImageRegular, WeaponType.REGULAR);
-                    setImage(Resources.pickup_weapon_regular);
+                    setImage(Resources.pickupWeaponRegular);
                     break;
                 // Double shoot
                 case 2:
                     content = new Weapon(Resources.weaponImageRegular, WeaponType.DOUBLE);
-                    setImage(Resources.pickup_weapon_double);
+                    setImage(Resources.pickupWeaponDouble);
                     break;
                 // Sticky weapon
                 case 3:
                     content = new Weapon(Resources.weaponImageSticky, WeaponType.STICKY);
-                    setImage(Resources.pickup_weapon_sticky);
+                    setImage(Resources.pickupWeaponSticky);
                     break;
                 // Flower weapon
                 case 4:
                     content = new Weapon(Resources.weaponImageFlower, WeaponType.FLOWER);
-                    setImage(Resources.pickup_weapon_flowers);
+                    setImage(Resources.pickupWeaponFlowers);
                     break;
                 default:
                     break;
@@ -65,19 +65,19 @@ public class Pickup extends GameObject {
             Powerup powerup = (Powerup) content;
             switch (powerup.getPowerType()) {
                 case INVINCIBLE:
-                    setImage(Resources.pickup_power_invincible);
+                    setImage(Resources.pickupPowerInvincible);
                     break;
                 case POINTS:
-                    setImage(Resources.pickup_power_points);
+                    setImage(Resources.pickupPowerPoints);
                     break;
                 case SHIELD:
-                    setImage(Resources.pickup_power_shield);
+                    setImage(Resources.pickupPowerShield);
                     break;
                 case SPEEDUP:
-                    setImage(Resources.pickup_power_speedup);
+                    setImage(Resources.pickupPowerSpeedup);
                     break;
                 case LIFE:
-                    setImage(Resources.pickup_utility_life);
+                    setImage(Resources.pickupUtilityLife);
                     break;
                 default:
                     break;
@@ -90,19 +90,19 @@ public class Pickup extends GameObject {
 
             switch (util.getType()) {
                 case FREEZE:
-                    setImage(Resources.pickup_utility_freeze);
+                    setImage(Resources.pickupUtilityFreeze);
                     break;
                 case LEVELWON:
-                    setImage(Resources.pickup_utility_levelwon);
+                    setImage(Resources.pickupUtilityLevelwon);
                     break;
                 case SLOW:
-                    setImage(Resources.pickup_utility_slow);
+                    setImage(Resources.pickupUtilitySlow);
                     break;
                 case SPLIT:
-                    setImage(Resources.pickup_utility_split);
+                    setImage(Resources.pickupUtilitySplit);
                     break;
                 case TIME:
-                    setImage(Resources.pickup_utility_time);
+                    setImage(Resources.pickupUtilityTime);
                     break;
                 default:
                     break;

--- a/src/main/java/nl/tudelft/model/pickups/Pickup.java
+++ b/src/main/java/nl/tudelft/model/pickups/Pickup.java
@@ -12,7 +12,7 @@ import org.newdawn.slick.SlickException;
 public class Pickup extends GameObject {
 
     private boolean onGround;
-    private PickupContent pickup;
+    private PickupContent content;
     private int tickCount;
 
     public enum WeaponType {
@@ -37,22 +37,22 @@ public class Pickup extends GameObject {
             switch (randomWeaponNr) {
             // regular weapon
                 case 1:
-                    pickup = new Weapon(Resources.weaponImageRegular, WeaponType.REGULAR);
+                    content = new Weapon(Resources.weaponImageRegular, WeaponType.REGULAR);
                     setImage(Resources.pickup_weapon_regular);
                     break;
                 // Double shoot
                 case 2:
-                    pickup = new Weapon(Resources.weaponImageRegular, WeaponType.DOUBLE);
+                    content = new Weapon(Resources.weaponImageRegular, WeaponType.DOUBLE);
                     setImage(Resources.pickup_weapon_double);
                     break;
                 // Sticky weapon
                 case 3:
-                    pickup = new Weapon(Resources.weaponImageSticky, WeaponType.STICKY);
+                    content = new Weapon(Resources.weaponImageSticky, WeaponType.STICKY);
                     setImage(Resources.pickup_weapon_sticky);
                     break;
                 // Flower weapon
                 case 4:
-                    pickup = new Weapon(Resources.weaponImageFlower, WeaponType.FLOWER);
+                    content = new Weapon(Resources.weaponImageFlower, WeaponType.FLOWER);
                     setImage(Resources.pickup_weapon_flowers);
                     break;
                 default:
@@ -61,9 +61,9 @@ public class Pickup extends GameObject {
 
         } else if (random > 3 && random < 7) {
             // new powerup
-            pickup = new Powerup(Helpers.randInt(1, 10));
-            Powerup up = (Powerup) pickup;
-            switch (up.getPowerType()) {
+            content = new Powerup(Helpers.randInt(1, 10));
+            Powerup powerup = (Powerup) content;
+            switch (powerup.getPowerType()) {
                 case INVINCIBLE:
                     setImage(Resources.pickup_power_invincible);
                     break;
@@ -85,8 +85,8 @@ public class Pickup extends GameObject {
         } else {
             // new utility
             int randomUtil = Helpers.randInt(1, 20);
-            pickup = new Utility(randomUtil);
-            Utility util = (Utility) pickup;
+            content = new Utility(randomUtil);
+            Utility util = (Utility) content;
 
             switch (util.getType()) {
                 case FREEZE:
@@ -123,7 +123,7 @@ public class Pickup extends GameObject {
     }
 
     public PickupContent getContent() {
-        return pickup;
+        return content;
     }
 
     public void setOnGround(boolean onGround) {

--- a/src/main/java/nl/tudelft/semgroup4/Dashboard.java
+++ b/src/main/java/nl/tudelft/semgroup4/Dashboard.java
@@ -24,8 +24,10 @@ public class Dashboard implements Renderable {
     private static float border = 2;
     private static float timeBarHeight = 30;
 
-    private final Image dashboardPlayerContainerLeft = Resources.dashboardPlayerContainerLeft.copy();
-    private final Image dashboardPlayerContainerRight = Resources.dashboardPlayerContainerRight.copy();
+    private final Image dashboardPlayerContainerLeft = Resources.dashboardPlayerContainerLeft
+            .copy();
+    private final Image dashboardPlayerContainerRight = Resources.dashboardPlayerContainerRight
+            .copy();
     private final Image dashboardLivesContainer = Resources.dashboardLivesContainer.copy();
     private final Image dashboardlivesFull = Resources.dashboardlivesFull.copy();
     private final Image dashboardlivesEmpty = Resources.dashboardlivesEmpty.copy();
@@ -54,10 +56,11 @@ public class Dashboard implements Renderable {
         this.right = right;
         this.bottom = bottom;
 
-        timeBarBackground = new Rectangle(left + margin, 0, right - left - 2 * margin,
-                timeBarHeight);
-        timeBar = new Rectangle(timeBarBackground.getX() + border, 0, timeBarBackground.getWidth()
-                - 2 * border, timeBarBackground.getHeight() - 2 * border);
+        timeBarBackground =
+                new Rectangle(left + margin, 0, right - left - 2 * margin, timeBarHeight);
+        timeBar =
+                new Rectangle(timeBarBackground.getX() + border, 0, timeBarBackground.getWidth()
+                        - 2 * border, timeBarBackground.getHeight() - 2 * border);
     }
 
     @Override
@@ -163,15 +166,18 @@ public class Dashboard implements Renderable {
     /**
      * Updates the dashboard every tick.
      * 
-     * @param delta int - Time since last call.
-     * @throws SlickException - If the Game engine crashes
+     * @param delta
+     *            int - Time since last call.
+     * @throws SlickException
+     *             - If the Game engine crashes
      */
     public void update(int delta) throws SlickException {
         timeBar.setWidth((right - left - margin * 2)
                 * ((float) game.getCurLevel().getTime() / game.getCurLevel().getMaxTime()));
 
         List<Player> players = game.getPlayers();
-        // this is een kleine workaround, eigenlijk moeten de player refs beschikbaar blijven zolang
+        // this is een kleine workaround, eigenlijk moeten de player refs beschikbaar blijven
+        // zolang
         // Game leeft
         // moet alleen niet gerendered, geupdate of gecollide worden als eentje dood is
         livesLeft = 0;

--- a/src/main/java/nl/tudelft/semgroup4/Dashboard.java
+++ b/src/main/java/nl/tudelft/semgroup4/Dashboard.java
@@ -24,12 +24,12 @@ public class Dashboard implements Renderable {
     private static float border = 2;
     private static float timeBarHeight = 30;
 
-    private Image dashboardPlayerContainerLeft = Resources.dashboardPlayerContainerLeft.copy();
-    private Image dashboardPlayerContainerRight = Resources.dashboardPlayerContainerRight.copy();
-    private Image dashboardLivesContainer = Resources.dashboardLivesContainer.copy();
-    private Image dashboardlivesFull = Resources.dashboardlivesFull.copy();
-    private Image dashboardlivesEmpty = Resources.dashboardlivesEmpty.copy();
-    private Image levelContainer = Resources.levelContainer.copy();
+    private final Image dashboardPlayerContainerLeft = Resources.dashboardPlayerContainerLeft.copy();
+    private final Image dashboardPlayerContainerRight = Resources.dashboardPlayerContainerRight.copy();
+    private final Image dashboardLivesContainer = Resources.dashboardLivesContainer.copy();
+    private final Image dashboardlivesFull = Resources.dashboardlivesFull.copy();
+    private final Image dashboardlivesEmpty = Resources.dashboardlivesEmpty.copy();
+    private final Image levelContainer = Resources.levelContainer.copy();
 
     private final Game game;
     private final Rectangle timeBarBackground;

--- a/src/main/java/nl/tudelft/semgroup4/GameState.java
+++ b/src/main/java/nl/tudelft/semgroup4/GameState.java
@@ -31,7 +31,7 @@ public class GameState extends BasicGameState {
     Input input = new Input(0);
     private Game theGame;
     private Dashboard dashboard;
-    private boolean singlePlayer;
+    private final boolean singlePlayer;
     QuadTree quad;
 
     public GameState(String title, boolean singlePlayer) {

--- a/src/main/java/nl/tudelft/semgroup4/PauseScreen.java
+++ b/src/main/java/nl/tudelft/semgroup4/PauseScreen.java
@@ -9,9 +9,9 @@ import org.newdawn.slick.gui.MouseOverArea;
 import org.newdawn.slick.state.StateBasedGame;
 
 public class PauseScreen {
-    private MouseOverArea mouseOver;
-    private Image pauseText = Resources.pauseText;
-    private Image quitText = Resources.quitText;
+    private final MouseOverArea mouseOver;
+    private final Image pauseText = Resources.pauseText;
+    private final Image quitText = Resources.quitText;
 
     public PauseScreen(MouseOverArea mouseOver) {
         this.mouseOver = mouseOver;

--- a/src/main/java/nl/tudelft/semgroup4/Resources.java
+++ b/src/main/java/nl/tudelft/semgroup4/Resources.java
@@ -50,23 +50,23 @@ public class Resources {
     public static Image bubbleImage5;
     public static Image bubbleImage6;
 
-    public static Image pickup_weapon_regular;
-    public static Image pickup_weapon_double;
-    public static Image pickup_weapon_sticky;
-    public static Image pickup_weapon_flowers;
-    public static Image pickup_power_shield;
-    public static Image pickup_power_invincible;
-    public static Image pickup_power_speedup;
-    public static Image pickup_power_points;
-    public static Image pickup_utility_split;
-    public static Image pickup_utility_freeze;
-    public static Image pickup_utility_slow;
-    public static Image pickup_utility_levelwon;
-    public static Image pickup_utility_time;
-    public static Image pickup_utility_life;
+    public static Image pickupWeaponRegular;
+    public static Image pickupWeaponDouble;
+    public static Image pickupWeaponSticky;
+    public static Image pickupWeaponFlowers;
+    public static Image pickupPowerShield;
+    public static Image pickupPowerInvincible;
+    public static Image pickupPowerSpeedup;
+    public static Image pickupPowerPoints;
+    public static Image pickupUtilitySplit;
+    public static Image pickupUtilityFreeze;
+    public static Image pickupUtilitySlow;
+    public static Image pickupUtilityLevelwon;
+    public static Image pickupUtilityTime;
+    public static Image pickupUtilityLife;
 
-    public static Image power_shield;
-    public static Image power_invincible;
+    public static Image powerShield;
+    public static Image powerInvincible;
 
     public static Sound bubblePop;
     public static Sound weaponFire;
@@ -138,23 +138,23 @@ public class Resources {
         bubbleImage5 = new Image("src/main/resources/img/rball5.png");
         bubbleImage6 = new Image("src/main/resources/img/rball6.png");
 
-        pickup_weapon_regular = new Image("src/main/resources/img/pickup_regular_weapon.png");
-        pickup_weapon_double = new Image("src/main/resources/img/pickup_weapon_double.png");
-        pickup_weapon_sticky = new Image("src/main/resources/img/pickup_sticky.png");
-        pickup_weapon_flowers = new Image("src/main/resources/img/pickup_flowers.png");
-        pickup_power_shield = new Image("src/main/resources/img/pickup_shield.png");
-        pickup_power_invincible = new Image("src/main/resources/img/pickup_invincible.png");
-        pickup_power_points = new Image("src/main/resources/img/pickup_points.png");
-        pickup_power_speedup = new Image("src/main/resources/img/pickup_speed.png");
-        pickup_utility_split = new Image("src/main/resources/img/pickup_split.png");
-        pickup_utility_freeze = new Image("src/main/resources/img/pickup_freeze.png");
-        pickup_utility_slow = new Image("src/main/resources/img/pickup_slow_down.png");
-        pickup_utility_levelwon = new Image("src/main/resources/img/pickup_level_won.png");
-        pickup_utility_time = new Image("src/main/resources/img/pickup_time.png");
-        pickup_utility_life = new Image("src/main/resources/img/pickup_life.png");
+        pickupWeaponRegular = new Image("src/main/resources/img/pickup_regular_weapon.png");
+        pickupWeaponDouble = new Image("src/main/resources/img/pickup_weapon_double.png");
+        pickupWeaponSticky = new Image("src/main/resources/img/pickup_sticky.png");
+        pickupWeaponFlowers = new Image("src/main/resources/img/pickup_flowers.png");
+        pickupPowerShield = new Image("src/main/resources/img/pickup_shield.png");
+        pickupPowerInvincible = new Image("src/main/resources/img/pickup_invincible.png");
+        pickupPowerPoints = new Image("src/main/resources/img/pickup_points.png");
+        pickupPowerSpeedup = new Image("src/main/resources/img/pickup_speed.png");
+        pickupUtilitySplit = new Image("src/main/resources/img/pickup_split.png");
+        pickupUtilityFreeze = new Image("src/main/resources/img/pickup_freeze.png");
+        pickupUtilitySlow = new Image("src/main/resources/img/pickup_slow_down.png");
+        pickupUtilityLevelwon = new Image("src/main/resources/img/pickup_level_won.png");
+        pickupUtilityTime = new Image("src/main/resources/img/pickup_time.png");
+        pickupUtilityLife = new Image("src/main/resources/img/pickup_life.png");
 
-        power_invincible = new Image("src/main/resources/img/powerup_invincible.png");
-        power_shield = new Image("src/main/resources/img/powerup_shield.png");
+        powerInvincible = new Image("src/main/resources/img/powerup_invincible.png");
+        powerShield = new Image("src/main/resources/img/powerup_shield.png");
     }
 
 }

--- a/src/main/java/nl/tudelft/semgroup4/collision/DefaultCollisionHandler.java
+++ b/src/main/java/nl/tudelft/semgroup4/collision/DefaultCollisionHandler.java
@@ -131,7 +131,7 @@ public class DefaultCollisionHandler implements CollisionHandler<GameObject, Gam
 
     final CollisionHandler<Bubble, Projectile> projectileBubbleHandler =
             (game, bubble, projectile) -> {
-        if (!projectile.getHitBubble()) {
+        if (!projectile.isHitBubble()) {
             projectile.setHitBubble();
             projectile.getWeapon().getPlayer().addScore(50);
             bubble.setIsHit();

--- a/src/main/java/nl/tudelft/semgroup4/util/Helpers.java
+++ b/src/main/java/nl/tudelft/semgroup4/util/Helpers.java
@@ -2,7 +2,14 @@ package nl.tudelft.semgroup4.util;
 
 import java.util.Random;
 
-public class Helpers {
+public final class Helpers {
+    
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private Helpers() {
+        
+    }
 
     /**
      * Generates a random integer.
@@ -13,7 +20,7 @@ public class Helpers {
      *            int - maximum value
      * @return int - a random int
      */
-    public static int randInt(int min, int max) {
+    public static final int randInt(int min, int max) {
         Random rand = new Random();
         return rand.nextInt((max - min) + 1) + min;
     }

--- a/src/main/java/nl/tudelft/semgroup4/util/Helpers.java
+++ b/src/main/java/nl/tudelft/semgroup4/util/Helpers.java
@@ -15,7 +15,6 @@ public class Helpers {
      */
     public static int randInt(int min, int max) {
         Random rand = new Random();
-        int randomNum = rand.nextInt((max - min) + 1) + min;
-        return randomNum;
+        return rand.nextInt((max - min) + 1) + min;
     }
 }

--- a/src/main/java/nl/tudelft/semgroup4/util/QuadTree.java
+++ b/src/main/java/nl/tudelft/semgroup4/util/QuadTree.java
@@ -57,13 +57,15 @@ public class QuadTree {
         int locY = (int) bounds.getY();
 
         nodes[0] =
-                new QuadTree(depthLevel + 1, new Rectangle(locX + subWidth, locY, subWidth, subHeight));
+                new QuadTree(depthLevel + 1, new Rectangle(locX + subWidth, locY, subWidth,
+                        subHeight));
         nodes[1] = new QuadTree(depthLevel + 1, new Rectangle(locX, locY, subWidth, subHeight));
         nodes[2] =
-                new QuadTree(depthLevel + 1, new Rectangle(locX, locY + subHeight, subWidth, subHeight));
-        nodes[3] =
-                new QuadTree(depthLevel + 1, new Rectangle(locX + subWidth, locY + subHeight, subWidth,
+                new QuadTree(depthLevel + 1, new Rectangle(locX, locY + subHeight, subWidth,
                         subHeight));
+        nodes[3] =
+                new QuadTree(depthLevel + 1, new Rectangle(locX + subWidth, locY + subHeight,
+                        subWidth, subHeight));
     }
 
     /**
@@ -108,7 +110,8 @@ public class QuadTree {
      * Insert the object into the quadtree. If the node exceeds the capacity, it will split and add
      * all objects to their corresponding nodes.
      * 
-     * @param rect GameObject - the object to insert.
+     * @param rect
+     *            GameObject - the object to insert.
      */
     public void insert(GameObject rect) {
         if (nodes[0] != null) {
@@ -143,8 +146,10 @@ public class QuadTree {
     /**
      * Return all objects that could collide with the given object.
      * 
-     * @param returnObjects List - a list of GameObjects.
-     * @param rect Shape - the given shape.
+     * @param returnObjects
+     *            List - a list of GameObjects.
+     * @param rect
+     *            Shape - the given shape.
      * @return List - the list of collidable objects.
      */
     public List<GameObject> retrieve(List<GameObject> returnObjects, Shape rect) {

--- a/src/main/java/nl/tudelft/semgroup4/util/QuadTree.java
+++ b/src/main/java/nl/tudelft/semgroup4/util/QuadTree.java
@@ -13,9 +13,9 @@ public class QuadTree {
     private static final int MAX_OBJECTS = 10;
     private static final int MAX_LEVELS = 3;
 
-    private int level;
-    private List<GameObject> objects;
-    private Rectangle bounds;
+    private final int depthLevel;
+    private final List<GameObject> objects;
+    private final Rectangle bounds;
     private QuadTree[] nodes;
 
     /**
@@ -27,7 +27,7 @@ public class QuadTree {
      *            Rectangle - the container to split in 4.
      */
     public QuadTree(int depthLevel, Rectangle bounds) {
-        this.level = depthLevel;
+        this.depthLevel = depthLevel;
         this.objects = new ArrayList<>();
         this.bounds = bounds;
         this.nodes = new QuadTree[4];
@@ -57,12 +57,12 @@ public class QuadTree {
         int locY = (int) bounds.getY();
 
         nodes[0] =
-                new QuadTree(level + 1, new Rectangle(locX + subWidth, locY, subWidth, subHeight));
-        nodes[1] = new QuadTree(level + 1, new Rectangle(locX, locY, subWidth, subHeight));
+                new QuadTree(depthLevel + 1, new Rectangle(locX + subWidth, locY, subWidth, subHeight));
+        nodes[1] = new QuadTree(depthLevel + 1, new Rectangle(locX, locY, subWidth, subHeight));
         nodes[2] =
-                new QuadTree(level + 1, new Rectangle(locX, locY + subHeight, subWidth, subHeight));
+                new QuadTree(depthLevel + 1, new Rectangle(locX, locY + subHeight, subWidth, subHeight));
         nodes[3] =
-                new QuadTree(level + 1, new Rectangle(locX + subWidth, locY + subHeight, subWidth,
+                new QuadTree(depthLevel + 1, new Rectangle(locX + subWidth, locY + subHeight, subWidth,
                         subHeight));
     }
 
@@ -123,7 +123,7 @@ public class QuadTree {
 
         objects.add(rect);
 
-        if (objects.size() > MAX_OBJECTS && level < MAX_LEVELS) {
+        if (objects.size() > MAX_OBJECTS && depthLevel < MAX_LEVELS) {
             if (nodes[0] == null) {
                 split();
             }

--- a/src/test/java/nl/tudelft/model/GameTest.java
+++ b/src/test/java/nl/tudelft/model/GameTest.java
@@ -28,7 +28,7 @@ public class GameTest extends OpenGLTestCase {
         LinkedList<Player> playerList = new LinkedList<>();
         playerList.add(mockedPlayer);
         Game game = new Game(mockedSbg, playerList, 0, 0);
-        assertFalse(game==null);
+        assertFalse(game == null);
         assertTrue(game.getPlayers().equals(playerList));
     }
 
@@ -85,7 +85,9 @@ public class GameTest extends OpenGLTestCase {
 
     /**
      * Test to check the level reset.
-     * @throws SlickException - Resources not found.
+     * 
+     * @throws SlickException
+     *             - Resources not found.
      */
     @Test
     public void testLevelReset1() throws SlickException {
@@ -103,7 +105,9 @@ public class GameTest extends OpenGLTestCase {
 
     /**
      * Test to check the level reset.
-     * @throws SlickException - Resources not found.
+     * 
+     * @throws SlickException
+     *             - Resources not found.
      */
     @Test
     public void testLevelReset2() throws SlickException {
@@ -121,7 +125,9 @@ public class GameTest extends OpenGLTestCase {
 
     /**
      * Test to check the level reset.
-     * @throws SlickException - Resources not found.
+     * 
+     * @throws SlickException
+     *             - Resources not found.
      */
     @Test
     public void testNextLevel1() throws SlickException {
@@ -138,7 +144,9 @@ public class GameTest extends OpenGLTestCase {
 
     /**
      * Test to check the level reset.
-     * @throws SlickException - Resources not found.
+     * 
+     * @throws SlickException
+     *             - Resources not found.
      */
     @Test
     public void testNextLevel2() throws SlickException {
@@ -172,7 +180,7 @@ public class GameTest extends OpenGLTestCase {
         CollisionHandler<GameObject, GameObject> handler = null;
         assertEquals(handler, null);
         handler = game.getNewCollisionHandler();
-        assertFalse(handler==null);
+        assertFalse(handler == null);
     }
 
     /**

--- a/src/test/java/nl/tudelft/model/GameTest.java
+++ b/src/test/java/nl/tudelft/model/GameTest.java
@@ -28,7 +28,7 @@ public class GameTest extends OpenGLTestCase {
         LinkedList<Player> playerList = new LinkedList<>();
         playerList.add(mockedPlayer);
         Game game = new Game(mockedSbg, playerList, 0, 0);
-        assertFalse(game.equals(null));
+        assertFalse(game==null);
         assertTrue(game.getPlayers().equals(playerList));
     }
 
@@ -172,7 +172,7 @@ public class GameTest extends OpenGLTestCase {
         CollisionHandler<GameObject, GameObject> handler = null;
         assertEquals(handler, null);
         handler = game.getNewCollisionHandler();
-        assertFalse(handler.equals(null));
+        assertFalse(handler==null);
     }
 
     /**

--- a/src/test/java/nl/tudelft/model/PlayerTest.java
+++ b/src/test/java/nl/tudelft/model/PlayerTest.java
@@ -13,17 +13,17 @@ import org.junit.Test;
  */
 public class PlayerTest extends OpenGLTestCase {
 
-    private final int speed = 4;
-    private final int playerScore = 100;
-    private final int playerLives = 3;
-    private final int playerTotalLives = 4;
+    private static final int SPEED = 4;
+    private static final int PLAYER_SCORE = 100;
+    private static final int PLAYER_LIVES = 3;
+    private static final int TOTAL_LIVES = 4;
 
     @Test
     public final void testConstructor() {
         Player player = new Player(0, 0, null, true);
         Weapon weapon = new Weapon(null, Pickup.WeaponType.REGULAR);
         assertEquals(player.getWeapon().getType(), weapon.getType());
-        assertEquals(player.getSpeed(), speed);
+        assertEquals(player.getSpeed(), SPEED);
         assertEquals(player.getPowerUps().size(), 0);
     }
 
@@ -35,7 +35,7 @@ public class PlayerTest extends OpenGLTestCase {
         powerup.setPowerType(PowerType.INVINCIBLE);
         player.getPowerUps().add(powerup);
         player.setWeapon(weapon);
-        player.setFireCounter(speed);
+        player.setFireCounter(SPEED);
         player.reset();
         assertEquals(player.getFireCounter(), 0);
         assertEquals(player.getPowerUps().size(), 0);
@@ -46,9 +46,9 @@ public class PlayerTest extends OpenGLTestCase {
     @Test
     public final void testRemoveSpeedUp() {
         Player player = new Player(0, 0, null, true);
-        player.setSpeed(2 * speed);
+        player.setSpeed(2 * SPEED);
         player.removeSpeedup();
-        assertEquals(player.getSpeed(), speed);
+        assertEquals(player.getSpeed(), SPEED);
     }
 
 
@@ -75,12 +75,12 @@ public class PlayerTest extends OpenGLTestCase {
         assertEquals(player.getPowerUps().size(), 1);
         player.addPowerup(speedUp);
         assertEquals(player.getPowerUps().size(), 1);
-        assertEquals(player.getSpeed(), 2 * speed);
+        assertEquals(player.getSpeed(), 2 * SPEED);
         assertEquals(player.getScore(), 0);
         player.addPowerup(score);
-        assertEquals(player.getScore(), playerScore);
-        assertEquals(player.getLives(), playerLives);
+        assertEquals(player.getScore(), PLAYER_SCORE);
+        assertEquals(player.getLives(), PLAYER_LIVES);
         player.addPowerup(lives);
-        assertEquals(player.getLives(), playerTotalLives);
+        assertEquals(player.getLives(), TOTAL_LIVES);
     }
 }

--- a/src/test/java/nl/tudelft/model/pickups/PickupTest.java
+++ b/src/test/java/nl/tudelft/model/pickups/PickupTest.java
@@ -49,19 +49,19 @@ public class PickupTest extends OpenGLTestCase {
             Powerup content = (Powerup)pickup.getContent();
             switch (content.getPowerType()) {
                 case INVINCIBLE:
-                    assertEquals(pickup.getImage(), Resources.pickup_power_invincible);
+                    assertEquals(pickup.getImage(), Resources.pickupPowerInvincible);
                     break;
                 case LIFE:
-                    assertEquals(pickup.getImage(), Resources.pickup_utility_life);
+                    assertEquals(pickup.getImage(), Resources.pickupUtilityLife);
                     break;
                 case POINTS:
-                    assertEquals(pickup.getImage(), Resources.pickup_power_points);
+                    assertEquals(pickup.getImage(), Resources.pickupPowerPoints);
                     break;
                 case SHIELD:
-                    assertEquals(pickup.getImage(), Resources.pickup_power_shield);
+                    assertEquals(pickup.getImage(), Resources.pickupPowerShield);
                     break;
                 case SPEEDUP:
-                    assertEquals(pickup.getImage(), Resources.pickup_power_speedup);
+                    assertEquals(pickup.getImage(), Resources.pickupPowerSpeedup);
                     break;
                 default:
                     break;
@@ -72,19 +72,19 @@ public class PickupTest extends OpenGLTestCase {
 
             switch (content2.getType()) {
                 case FREEZE:
-                    assertEquals(pickup2.getImage(), Resources.pickup_utility_freeze);
+                    assertEquals(pickup2.getImage(), Resources.pickupUtilityFreeze);
                     break;
                 case LEVELWON:
-                    assertEquals(pickup2.getImage(), Resources.pickup_utility_levelwon);
+                    assertEquals(pickup2.getImage(), Resources.pickupUtilityLevelwon);
                     break;
                 case SLOW:
-                    assertEquals(pickup2.getImage(), Resources.pickup_utility_slow);
+                    assertEquals(pickup2.getImage(), Resources.pickupUtilitySlow);
                     break;
                 case SPLIT:
-                    assertEquals(pickup2.getImage(), Resources.pickup_utility_split);
+                    assertEquals(pickup2.getImage(), Resources.pickupUtilitySplit);
                     break;
                 case TIME:
-                    assertEquals(pickup2.getImage(), Resources.pickup_utility_time);
+                    assertEquals(pickup2.getImage(), Resources.pickupUtilityTime);
                     break;
                 default:
                     break;

--- a/src/test/java/nl/tudelft/model/pickups/PowerupTest.java
+++ b/src/test/java/nl/tudelft/model/pickups/PowerupTest.java
@@ -13,18 +13,18 @@ public class PowerupTest {
     @Test
     public void testPowerup() {
         for (int random = 1; random <= 10; random++) {
-            Powerup up = new Powerup(random);
+            Powerup powerup = new Powerup(random);
             
             if (random == 10) {
-                assertEquals(up.getPowerType(), PowerType.LIFE);
+                assertEquals(powerup.getPowerType(), PowerType.LIFE);
             } else if (random > 8) {
-                assertEquals(up.getPowerType(), PowerType.INVINCIBLE);
+                assertEquals(powerup.getPowerType(), PowerType.INVINCIBLE);
             } else if (random > 6) {
-                assertEquals(up.getPowerType(), PowerType.SHIELD);
+                assertEquals(powerup.getPowerType(), PowerType.SHIELD);
             } else if (random > 4) {
-                assertEquals(up.getPowerType(), PowerType.SPEEDUP);
+                assertEquals(powerup.getPowerType(), PowerType.SPEEDUP);
             } else {
-                assertEquals(up.getPowerType(), PowerType.POINTS);
+                assertEquals(powerup.getPowerType(), PowerType.POINTS);
             }
         }
     }


### PR DESCRIPTION
Fixes a lot of pmd violations. This is the main deal of violations and is a first attempt at cleaning up the code base.

Most changes revolve around renaming variables.

Note that a bug was found for the file logger on windows systems: the test cleanup does not remove temporary log outputs created during the tests.

<naming,layout