### PR TITLE
Add complete tests for Input

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -155,7 +155,7 @@
             <property name="arrayInitIndent" value="4"/>
         </module>
         <module name="AbbreviationAsWordInName">
-            <property name="allowedAbbreviationLength" value="3"/>
+            <property name="allowedAbbreviationLength" value="5"/>
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>

--- a/src/main/java/nl/tudelft/semgroup4/eventhandlers/PlayerEventHandler.java
+++ b/src/main/java/nl/tudelft/semgroup4/eventhandlers/PlayerEventHandler.java
@@ -43,4 +43,13 @@ public class PlayerEventHandler implements Observer {
         }
     }
 
+    /**
+     * Accesses the {@link Player} that this {@link PlayerEventHandler} delegates events to.
+     * 
+     * @return {@link Player} - The player.
+     */
+    protected final Player getPlayer() {
+        return player;
+    }
+
 }

--- a/src/main/java/nl/tudelft/semgroup4/eventhandlers/PlayerInput.java
+++ b/src/main/java/nl/tudelft/semgroup4/eventhandlers/PlayerInput.java
@@ -98,6 +98,11 @@ public class PlayerInput extends Observable implements Observer {
     /**
      * Sets a new key as the input for moving left.
      * 
+     * <p>
+     * Assures that this object removes itself from the old input and subscribes itself to the new
+     * input.
+     * </p>
+     * 
      * @param leftInput
      *            {@link InputKey} - The leftInput to set.
      */
@@ -109,6 +114,11 @@ public class PlayerInput extends Observable implements Observer {
     /**
      * Sets a new key as the input for moving right.
      * 
+     * <p>
+     * Assures that this object removes itself from the old input and subscribes itself to the new
+     * input.
+     * </p>
+     * 
      * @param rightInput
      *            {@link InputKey} - The rightInput to set.
      */
@@ -119,6 +129,11 @@ public class PlayerInput extends Observable implements Observer {
 
     /**
      * Sets a new key as the input for shooting.
+     * 
+     * <p>
+     * Assures that this object removes itself from the old input and subscribes itself to the new
+     * input.
+     * </p>
      * 
      * @param shootInput
      *            {@link InputKey} - The shootInput to set.

--- a/src/main/java/nl/tudelft/semgroup4/eventhandlers/PlayerInput.java
+++ b/src/main/java/nl/tudelft/semgroup4/eventhandlers/PlayerInput.java
@@ -107,6 +107,7 @@ public class PlayerInput extends Observable implements Observer {
      *            {@link InputKey} - The leftInput to set.
      */
     public final void setLeftInput(InputKey leftInput) {
+        this.leftInput.deleteObserver(this);
         this.leftInput = leftInput;
         this.leftInput.addObserver(this);
     }
@@ -123,6 +124,7 @@ public class PlayerInput extends Observable implements Observer {
      *            {@link InputKey} - The rightInput to set.
      */
     public final void setRightInput(InputKey rightInput) {
+        this.rightInput.deleteObserver(this);
         this.rightInput = rightInput;
         this.rightInput.addObserver(this);
     }
@@ -139,6 +141,7 @@ public class PlayerInput extends Observable implements Observer {
      *            {@link InputKey} - The shootInput to set.
      */
     public final void setShootInput(InputKey shootInput) {
+        this.shootInput.deleteObserver(this);
         this.shootInput = shootInput;
         this.shootInput.addObserver(this);
     }

--- a/src/test/java/nl/tudelft/semgroup4/eventhandlers/PlayerEventHandlerTest.java
+++ b/src/test/java/nl/tudelft/semgroup4/eventhandlers/PlayerEventHandlerTest.java
@@ -18,8 +18,11 @@ public class PlayerEventHandlerTest {
     private PlayerEventHandler defaultHandler;
     private Observable mockedObservable;
 
+    /**
+     * Creates all dependencies and instantiations.
+     */
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         mockedPlayer = Mockito.mock(Player.class);
         defaultHandler = new PlayerEventHandler(mockedPlayer);
         mockedObservable = Mockito.mock(PlayerInput.class);

--- a/src/test/java/nl/tudelft/semgroup4/eventhandlers/PlayerEventHandlerTest.java
+++ b/src/test/java/nl/tudelft/semgroup4/eventhandlers/PlayerEventHandlerTest.java
@@ -1,0 +1,65 @@
+package nl.tudelft.semgroup4.eventhandlers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.Observable;
+
+import nl.tudelft.model.Player;
+import nl.tudelft.semgroup4.eventhandlers.PlayerInput.PlayerEvent;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class PlayerEventHandlerTest {
+
+    private Player mockedPlayer;
+    private PlayerEventHandler defaultHandler;
+    private Observable mockedObservable;
+
+    @Before
+    public void setUp() throws Exception {
+        mockedPlayer = Mockito.mock(Player.class);
+        defaultHandler = new PlayerEventHandler(mockedPlayer);
+        mockedObservable = Mockito.mock(PlayerInput.class);
+    }
+
+    @Test
+    public void testPlayerEventHandler() {
+        assertEquals(mockedPlayer, defaultHandler.getPlayer());
+        Player secondPlayer = Mockito.mock(Player.class);
+        assertNotEquals(secondPlayer, defaultHandler.getPlayer());
+    }
+
+    @Test
+    public void testUpdateLeftEvent() {
+        defaultHandler.update(mockedObservable, PlayerEvent.LEFT);
+        Mockito.verify(mockedPlayer).moveLeft();
+    }
+
+    @Test
+    public void testUpdateRightEvent() {
+        defaultHandler.update(mockedObservable, PlayerEvent.RIGHT);
+        Mockito.verify(mockedPlayer).moveRight();
+    }
+
+    @Test
+    public void testUpdateShootEvent() {
+        defaultHandler.update(mockedObservable, PlayerEvent.SHOOT);
+        Mockito.verify(mockedPlayer).fireWeapon();
+    }
+
+    @Test
+    public void testUpdateStillEvent() {
+        defaultHandler.update(mockedObservable, PlayerEvent.STILL);
+        Mockito.verify(mockedPlayer).stopMoving();
+    }
+
+    @Test
+    public void testUpdateNoEvent() {
+        defaultHandler.update(mockedObservable, null);
+        Mockito.verifyZeroInteractions(mockedPlayer);
+    }
+
+}

--- a/src/test/java/nl/tudelft/semgroup4/eventhandlers/PlayerInputTest.java
+++ b/src/test/java/nl/tudelft/semgroup4/eventhandlers/PlayerInputTest.java
@@ -119,9 +119,7 @@ public class PlayerInputTest {
         defaultInstance.poll();
         Mockito.verify(mockedLeftKey).poll();
         Mockito.verify(mockedRightKey).poll();
-        ;
         Mockito.verify(mockedShootKey).poll();
-        ;
     }
 
     @Test
@@ -129,6 +127,9 @@ public class PlayerInputTest {
         InputKey newInput = Mockito.mock(InputKey.class);
         defaultInstance.setLeftInput(newInput);
         assertEquals(newInput, defaultInstance.getLeftInput());
+        Mockito.verify(mockedLeftKey).deleteObserver(defaultInstance);
+        Mockito.verify(newInput).addObserver(defaultInstance);
+
     }
 
     @Test
@@ -136,6 +137,8 @@ public class PlayerInputTest {
         InputKey newInput = Mockito.mock(InputKey.class);
         defaultInstance.setRightInput(newInput);
         assertEquals(newInput, defaultInstance.getRightInput());
+        Mockito.verify(mockedRightKey).deleteObserver(defaultInstance);
+        Mockito.verify(newInput).addObserver(defaultInstance);
     }
 
     @Test
@@ -143,6 +146,8 @@ public class PlayerInputTest {
         InputKey newInput = Mockito.mock(InputKey.class);
         defaultInstance.setShootInput(newInput);
         assertEquals(newInput, defaultInstance.getShootInput());
+        Mockito.verify(mockedShootKey).deleteObserver(defaultInstance);
+        Mockito.verify(newInput).addObserver(defaultInstance);
     }
 
     @Test

--- a/src/test/java/nl/tudelft/semgroup4/eventhandlers/PlayerInputTest.java
+++ b/src/test/java/nl/tudelft/semgroup4/eventhandlers/PlayerInputTest.java
@@ -3,7 +3,6 @@ package nl.tudelft.semgroup4.eventhandlers;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.awt.DefaultKeyboardFocusManager;
 import java.util.Observable;
 import java.util.Observer;
 


### PR DESCRIPTION
Adds tests for the PlayerEventHandler

Elaborates the tests for the PlayerInput setters to correctly clear old Observables, preventing memory leakage. (also implements the changes necessary to conform to this stricter contract).

< testing, organisation, interface