### PR TITLE
Add Level Render Tests

### DIFF
--- a/src/main/java/nl/tudelft/model/Level.java
+++ b/src/main/java/nl/tudelft/model/Level.java
@@ -10,10 +10,10 @@ import nl.tudelft.semgroup4.Modifiable;
 import nl.tudelft.semgroup4.Renderable;
 import nl.tudelft.semgroup4.Updateable;
 import nl.tudelft.semgroup4.resources.ResourcesWrapper;
-import nl.tudelft.semgroup4.util.Helpers;
 
 import org.newdawn.slick.GameContainer;
 import org.newdawn.slick.Graphics;
+import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
 
 /**
@@ -32,8 +32,9 @@ public class Level implements Updateable, Renderable, Modifiable {
     private final LinkedList<AbstractBubble> bubbles;
     private final LinkedList<AbstractGameObject> pendingRemoval = new LinkedList<>();
     private final LinkedList<AbstractGameObject> pendingAddition = new LinkedList<>();
+    private final Image backgroundImage;
     private int time;
-    private final int maxTime;
+    private int maxTime;
     private final int id;
     private boolean shopSlow = false;
 
@@ -53,8 +54,10 @@ public class Level implements Updateable, Renderable, Modifiable {
      * @param id
      *            int - the number of this level.
      */
-    public Level(LinkedList<AbstractWall> walls, LinkedList<Projectile> projectiles,
-            LinkedList<Pickup> pickups, LinkedList<AbstractBubble> bubbles, int time, int id) {
+    public Level(Image backgroundImage, LinkedList<AbstractWall> walls,
+            LinkedList<Projectile> projectiles, LinkedList<Pickup> pickups,
+            LinkedList<AbstractBubble> bubbles, int time, int id) {
+        this.backgroundImage = backgroundImage;
         this.walls = walls;
         this.projectiles = projectiles;
         this.bubbles = bubbles;
@@ -123,10 +126,8 @@ public class Level implements Updateable, Renderable, Modifiable {
 
     @Override
     public void render(GameContainer container, Graphics graphics) throws SlickException {
-        final ResourcesWrapper resources = new ResourcesWrapper();
-        graphics.drawImage(resources.getBackgroundImage(), 0, 0, container.getWidth(),
-                container.getHeight(), 0, 0, resources.getBackgroundImage().getWidth(),
-                resources.getBackgroundImage().getHeight());
+        graphics.drawImage(backgroundImage, 0, 0, container.getWidth(), container.getHeight(),
+                0, 0, backgroundImage.getWidth(), backgroundImage.getHeight());
 
         for (AbstractGameObject gameObject : projectiles) {
             gameObject.render(container, graphics);

--- a/src/main/java/nl/tudelft/model/Level.java
+++ b/src/main/java/nl/tudelft/model/Level.java
@@ -40,7 +40,9 @@ public class Level implements Updateable, Renderable, Modifiable {
 
     /**
      * Creates a level object with an object list, a timer and a speed.
-     *
+     * 
+     * @param backgroundImage
+     *            {@link Image} - The image to render as background.
      * @param walls
      *            LinkedList - list containing all walls in this level.
      * @param projectiles

--- a/src/main/java/nl/tudelft/model/Level.java
+++ b/src/main/java/nl/tudelft/model/Level.java
@@ -250,7 +250,7 @@ public class Level implements Updateable, Renderable, Modifiable {
      *            int - the total amount of time in milliseconds.
      */
     public void setMaxTime(int time) {
-        this.time = time;
+        this.maxTime = time;
     }
 
     /**

--- a/src/main/java/nl/tudelft/model/LevelFactory.java
+++ b/src/main/java/nl/tudelft/model/LevelFactory.java
@@ -125,28 +125,32 @@ public class LevelFactory {
 
         // Create Bubbles for level
         LinkedList<AbstractBubble> bubbles = new LinkedList<>();
-        
+
         AbstractBubble bubble = new Bubble1Factory(resources).createBubble();
         bubble.setLocX(resources.getVwallImage().getWidth() + 100);
-        bubble.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight() 
+        bubble.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight()
                 - bubble.getWidth() - 400);
         bubbles.add(bubble);
 
         LinkedList<AbstractWall> walls = wallInit();
-        
-        HorMovingWall movingWall = new HorMovingWall(resources.getSmallHWallImage(), 300, 200, 2);
-        HorMovingWall movingWall2 = new HorMovingWall(resources.getSmallHWallImage(), 800, 200, -2);
+
+        HorMovingWall movingWall =
+                new HorMovingWall(resources.getSmallHWallImage(), 300, 200, 2);
+        HorMovingWall movingWall2 =
+                new HorMovingWall(resources.getSmallHWallImage(), 800, 200, -2);
         walls.add(movingWall);
         walls.add(movingWall2);
-        
-        VerMovingWall movingWall3 = new VerMovingWall(resources.getSmallVWallImage(), 200, 200, -2);
+
+        VerMovingWall movingWall3 =
+                new VerMovingWall(resources.getSmallVWallImage(), 200, 200, -2);
         walls.add(movingWall3);
-        
+
         LinkedList<Projectile> projectiles = new LinkedList<>();
         LinkedList<Pickup> pickups = new LinkedList<>();
         int time = 120000;
 
-        return new Level(resources.getBackgroundImage(), walls, projectiles, pickups, bubbles, time, id);
+        return new Level(resources.getBackgroundImage(), walls, projectiles, pickups, bubbles,
+                time, id);
     }
 
     /**
@@ -159,36 +163,41 @@ public class LevelFactory {
 
         // Create Bubbles for level
         LinkedList<AbstractBubble> bubbles = new LinkedList<>();
-        
+
         AbstractBubble bubble1 = new Bubble6Factory(resources).createBubble();
         bubble1.setLocX(resources.getVwallImage().getWidth() + 100);
-        bubble1.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight() 
+        bubble1.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight()
                 - bubble1.getHeight() - 400);
         bubbles.add(bubble1);
-        
+
         AbstractBubble bubble2 = new Bubble5Factory(resources).createBubble();
         bubble2.setLocX(resources.getVwallImage().getWidth() + 300);
-        bubble2.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight() 
+        bubble2.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight()
                 - bubble2.getHeight() - 400);
         bubbles.add(bubble2);
-        
+
         LinkedList<AbstractWall> walls = wallInit();
-        
-        HorMovingWall movingWall = new HorMovingWall(resources.getSmallHWallImage(), 300, 400, 2);
-        HorMovingWall movingWall2 = new HorMovingWall(resources.getSmallHWallImage(), 800, 400, -2);
+
+        HorMovingWall movingWall =
+                new HorMovingWall(resources.getSmallHWallImage(), 300, 400, 2);
+        HorMovingWall movingWall2 =
+                new HorMovingWall(resources.getSmallHWallImage(), 800, 400, -2);
         walls.add(movingWall);
         walls.add(movingWall2);
-        
-        VerMovingWall movingWall3 = new VerMovingWall(resources.getSmallVWallImage(), 250, 200, -2);
+
+        VerMovingWall movingWall3 =
+                new VerMovingWall(resources.getSmallVWallImage(), 250, 200, -2);
         walls.add(movingWall3);
-        VerMovingWall movingWall4 = new VerMovingWall(resources.getSmallVWallImage(), 400, 200, -2);
+        VerMovingWall movingWall4 =
+                new VerMovingWall(resources.getSmallVWallImage(), 400, 200, -2);
         walls.add(movingWall4);
 
         LinkedList<Projectile> projectiles = new LinkedList<>();
         LinkedList<Pickup> pickups = new LinkedList<>();
         int time = 120000;
-        
-        return new Level(resources.getBackgroundImage(), walls, projectiles, pickups, bubbles, time, id);
+
+        return new Level(resources.getBackgroundImage(), walls, projectiles, pickups, bubbles,
+                time, id);
 
     }
 
@@ -204,22 +213,22 @@ public class LevelFactory {
 
         // Create Bubbles for level
         LinkedList<AbstractBubble> bubbles = new LinkedList<>();
-        
+
         AbstractBubble bubble1 = new Bubble3Factory(resources).createBubble();
         bubble1.setLocX(resources.getVwallImage().getWidth() + 100);
-        bubble1.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight() 
+        bubble1.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight()
                 - bubble1.getHeight() - 400);
         bubbles.add(bubble1);
-        
+
         AbstractBubble bubble2 = new Bubble3Factory(resources).createBubble();
         bubble2.setLocX(resources.getVwallImage().getWidth() + 200);
-        bubble2.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight() 
+        bubble2.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight()
                 - bubble2.getHeight() - 400);
         bubbles.add(bubble2);
-        
+
         AbstractBubble bubble3 = new Bubble3Factory(resources).createBubble();
         bubble3.setLocX(resources.getVwallImage().getWidth() + 300);
-        bubble3.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight() 
+        bubble3.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight()
                 - bubble3.getHeight() - 400);
         bubbles.add(bubble3);
 
@@ -227,7 +236,8 @@ public class LevelFactory {
         LinkedList<Pickup> pickups = new LinkedList<>();
         int time = 120000;
 
-        return new Level(resources.getBackgroundImage(), walls, projectiles, pickups, bubbles, time, id);
+        return new Level(resources.getBackgroundImage(), walls, projectiles, pickups, bubbles,
+                time, id);
 
     }
 
@@ -243,40 +253,40 @@ public class LevelFactory {
 
         // Create Bubbles for level
         LinkedList<AbstractBubble> bubbles = new LinkedList<>();
-        
+
         AbstractBubble bubble1 = new Bubble6Factory(resources).createBubble();
         bubble1.setLocX(resources.getVwallImage().getWidth() + 100);
-        bubble1.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight() 
+        bubble1.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight()
                 - bubble1.getHeight() - 400);
         bubbles.add(bubble1);
-        
+
         AbstractBubble bubble2 = new Bubble5Factory(resources).createBubble();
         bubble2.setLocX(resources.getVwallImage().getWidth() + 200);
-        bubble2.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight() 
+        bubble2.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight()
                 - bubble2.getHeight() - 400);
         bubbles.add(bubble2);
-        
+
         AbstractBubble bubble3 = new Bubble4Factory(resources).createBubble();
         bubble3.setLocX(resources.getVwallImage().getWidth() + 300);
-        bubble3.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight() 
+        bubble3.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight()
                 - bubble3.getHeight() - 400);
         bubbles.add(bubble3);
-        
+
         AbstractBubble bubble4 = new Bubble3Factory(resources).createBubble();
         bubble4.setLocX(resources.getVwallImage().getWidth() + 400);
-        bubble4.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight() 
+        bubble4.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight()
                 - bubble4.getHeight() - 400);
         bubbles.add(bubble4);
-        
+
         AbstractBubble bubble5 = new Bubble2Factory(resources).createBubble();
         bubble5.setLocX(resources.getVwallImage().getWidth() + 500);
-        bubble5.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight() 
+        bubble5.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight()
                 - bubble5.getHeight() - 400);
         bubbles.add(bubble5);
-        
+
         AbstractBubble bubble6 = new Bubble1Factory(resources).createBubble();
         bubble6.setLocX(resources.getVwallImage().getWidth() + 600);
-        bubble6.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight() 
+        bubble6.setLocY(game.getContainerHeight() - resources.getWallImage().getHeight()
                 - bubble6.getHeight() - 400);
         bubbles.add(bubble6);
 
@@ -284,6 +294,7 @@ public class LevelFactory {
         LinkedList<Pickup> pickups = new LinkedList<>();
         int time = 240000;
 
-        return new Level(resources.getBackgroundImage(), walls, projectiles, pickups, bubbles, time, id);
+        return new Level(resources.getBackgroundImage(), walls, projectiles, pickups, bubbles,
+                time, id);
     }
 }

--- a/src/main/java/nl/tudelft/model/LevelFactory.java
+++ b/src/main/java/nl/tudelft/model/LevelFactory.java
@@ -146,7 +146,7 @@ public class LevelFactory {
         LinkedList<Pickup> pickups = new LinkedList<>();
         int time = 120000;
 
-        return new Level(walls, projectiles, pickups, bubbles, time, id);
+        return new Level(resources.getBackgroundImage(), walls, projectiles, pickups, bubbles, time, id);
     }
 
     /**
@@ -188,7 +188,7 @@ public class LevelFactory {
         LinkedList<Pickup> pickups = new LinkedList<>();
         int time = 120000;
         
-        return new Level(walls, projectiles, pickups, bubbles, time, id);
+        return new Level(resources.getBackgroundImage(), walls, projectiles, pickups, bubbles, time, id);
 
     }
 
@@ -227,7 +227,7 @@ public class LevelFactory {
         LinkedList<Pickup> pickups = new LinkedList<>();
         int time = 120000;
 
-        return new Level(walls, projectiles, pickups, bubbles, time, id);
+        return new Level(resources.getBackgroundImage(), walls, projectiles, pickups, bubbles, time, id);
 
     }
 
@@ -284,6 +284,6 @@ public class LevelFactory {
         LinkedList<Pickup> pickups = new LinkedList<>();
         int time = 240000;
 
-        return new Level(walls, projectiles, pickups, bubbles, time, id);
+        return new Level(resources.getBackgroundImage(), walls, projectiles, pickups, bubbles, time, id);
     }
 }

--- a/src/test/java/nl/tudelft/model/LevelTest.java
+++ b/src/test/java/nl/tudelft/model/LevelTest.java
@@ -56,9 +56,9 @@ public class LevelTest {
         mockedImage = Mockito.mock(Image.class);
         level = new Level(mockedImage, walls, projectiles, pickups, bubbles, 3, 1);
     }
+
     /**
-     * Test to test the constructor for level.
-     * This test also tests the getters.
+     * Test to test the constructor for level. This test also tests the getters.
      */
     @Test
     public void testLevel() {
@@ -108,7 +108,9 @@ public class LevelTest {
 
     /**
      * Test to check the update method for level.
-     * @throws SlickException : An exception created by Slick.
+     * 
+     * @throws SlickException
+     *             : An exception created by Slick.
      */
     @Test
     public void testUpdate1() throws SlickException {
@@ -122,7 +124,9 @@ public class LevelTest {
 
     /**
      * Test to check the update method for level.
-     * @throws SlickException : An exception created by Slick.
+     * 
+     * @throws SlickException
+     *             : An exception created by Slick.
      */
     @Test
     public void testUpdate2() throws SlickException {
@@ -144,7 +148,9 @@ public class LevelTest {
 
     /**
      * Test to check the update method for level.
-     * @throws SlickException : An exception created by Slick.
+     * 
+     * @throws SlickException
+     *             : An exception created by Slick.
      */
     @Test
     public void testUpdate3() throws SlickException {
@@ -172,7 +178,7 @@ public class LevelTest {
         assertFalse(pickups.contains(mockedPickup));
         assertFalse(projectiles.contains(mockedProjectile));
     }
-    
+
     @Test
     public void testUpdateShopSlowActive() throws SlickException {
         Modifiable modifiable = mock(Modifiable.class);
@@ -188,7 +194,9 @@ public class LevelTest {
 
     /**
      * Test to check the splitAllBubbles method for level.
-     * @throws SlickException : An exception created by Slick.
+     * 
+     * @throws SlickException
+     *             : An exception created by Slick.
      */
     @Test
     public void testSplitAllBubbles1() throws SlickException {
@@ -200,7 +208,9 @@ public class LevelTest {
 
     /**
      * Test to check the splitAllBubbles method for level.
-     * @throws SlickException : An exception created by Slick.
+     * 
+     * @throws SlickException
+     *             : An exception created by Slick.
      */
     @Test
     public void testSplitAllBubbles2() throws SlickException {
@@ -212,7 +222,9 @@ public class LevelTest {
 
     /**
      * Test to check the splitAllBubbles method for level.
-     * @throws SlickException : An exception created by Slick.
+     * 
+     * @throws SlickException
+     *             : An exception created by Slick.
      */
     @Test
     public void testSplitAllBubbles3() throws SlickException {
@@ -222,32 +234,32 @@ public class LevelTest {
         level.splitAllBubbles(bubbles, false);
         verify(mockedBubble, times(1)).getNext();
     }
-    
+
     @Test
     public void testGetSetMaxTime() {
         assertEquals(3, level.getMaxTime());
         level.setMaxTime(34);
         assertEquals(34, level.getMaxTime());
     }
-    
+
     @Test
     public void render() throws SlickException {
         GameContainer mockedContainer = Mockito.mock(GameContainer.class);
-        Graphics mockedGraphics  = Mockito.mock(Graphics.class);
+        Graphics mockedGraphics = Mockito.mock(Graphics.class);
         Mockito.when(mockedImage.getWidth()).thenReturn(1);
         Mockito.when(mockedImage.getHeight()).thenReturn(1);
         level.render(mockedContainer, mockedGraphics);
-        
-        for(AbstractGameObject gameObject : bubbles) {
+
+        for (AbstractGameObject gameObject : bubbles) {
             Mockito.verify(gameObject).render(mockedContainer, mockedGraphics);
         }
-        for(AbstractGameObject gameObject : walls) {
+        for (AbstractGameObject gameObject : walls) {
             Mockito.verify(gameObject).render(mockedContainer, mockedGraphics);
         }
-        for(AbstractGameObject gameObject : bubbles) {
+        for (AbstractGameObject gameObject : bubbles) {
             Mockito.verify(gameObject).render(mockedContainer, mockedGraphics);
         }
-        for(AbstractGameObject gameObject : pickups) {
+        for (AbstractGameObject gameObject : pickups) {
             Mockito.verify(gameObject).render(mockedContainer, mockedGraphics);
         }
     }

--- a/src/test/java/nl/tudelft/model/LevelTest.java
+++ b/src/test/java/nl/tudelft/model/LevelTest.java
@@ -17,21 +17,28 @@ import nl.tudelft.model.pickups.Pickup;
 import nl.tudelft.model.pickups.weapon.Projectile;
 import nl.tudelft.model.wall.AbstractWall;
 import nl.tudelft.semgroup4.Modifiable;
+import nl.tudelft.semgroup4.resources.ResourcesWrapper;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.newdawn.slick.GameContainer;
+import org.newdawn.slick.Graphics;
+import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
 
 public class LevelTest {
 
-    public LinkedList<AbstractWall> walls = new LinkedList<AbstractWall>();
-    public LinkedList<Projectile> projectiles = new LinkedList<Projectile>();
-    public LinkedList<Pickup> pickups = new LinkedList<Pickup>();
-    public LinkedList<AbstractBubble> bubbles = new LinkedList<AbstractBubble>();
-    public AbstractBubble bubble;
-    public AbstractWall wall;
-    public Projectile projectile;
-    public Pickup pickup;
+    private LinkedList<AbstractWall> walls = new LinkedList<AbstractWall>();
+    private LinkedList<Projectile> projectiles = new LinkedList<Projectile>();
+    private LinkedList<Pickup> pickups = new LinkedList<Pickup>();
+    private LinkedList<AbstractBubble> bubbles = new LinkedList<AbstractBubble>();
+    private AbstractBubble bubble;
+    private AbstractWall wall;
+    private Projectile projectile;
+    private Pickup pickup;
+    private Image mockedImage;
+    private Level level;
 
     /**
      * Create mocks for all elements in linked lists.
@@ -46,6 +53,8 @@ public class LevelTest {
         pickups.add(pickup);
         bubble = mock(AbstractBubble.class);
         bubbles.add(bubble);
+        mockedImage = Mockito.mock(Image.class);
+        level = new Level(mockedImage, walls, projectiles, pickups, bubbles, 3, 1);
     }
     /**
      * Test to test the constructor for level.
@@ -53,11 +62,10 @@ public class LevelTest {
      */
     @Test
     public void testLevel() {
-        Level level = new Level(walls, projectiles, pickups, bubbles, 1, 1);
         assertEquals(level.getBubbles(), bubbles);
         assertEquals(level.getId(), 1);
-        assertEquals(level.getTime(), 1);
-        assertEquals(level.getMaxTime(), 1);
+        assertEquals(level.getTime(), 3);
+        assertEquals(level.getMaxTime(), 3);
         assertEquals(level.getWalls(), walls);
         assertEquals(level.getProjectiles(), projectiles);
         assertEquals(level.getPickups(), pickups);
@@ -68,7 +76,6 @@ public class LevelTest {
      */
     @Test
     public void testIsCompleted() {
-        Level level = new Level(walls, projectiles, pickups, bubbles, 1, 1);
         assertFalse(level.isCompleted());
     }
 
@@ -77,7 +84,6 @@ public class LevelTest {
      */
     @Test
     public void testTimeExpired1() {
-        Level level = new Level(walls, projectiles, pickups, bubbles, 1, 1);
         assertFalse(level.timerExpired());
     }
 
@@ -86,7 +92,7 @@ public class LevelTest {
      */
     @Test
     public void testTimeExpired2() {
-        Level level = new Level(walls, projectiles, pickups, bubbles, 0, 1);
+        level.setTime(0);
         assertTrue(level.timerExpired());
     }
 
@@ -95,8 +101,7 @@ public class LevelTest {
      */
     @Test
     public void testSetTime() {
-        Level level = new Level(walls, projectiles, pickups, bubbles, 1, 1);
-        assertTrue(level.getTime() == 1);
+        assertTrue(level.getTime() == 3);
         level.setTime(2);
         assertTrue(level.getTime() == 2);
     }
@@ -107,14 +112,12 @@ public class LevelTest {
      */
     @Test
     public void testUpdate1() throws SlickException {
-        Level level = new Level(walls, projectiles, pickups, bubbles, 2, 1);
         Modifiable modifiable = mock(Modifiable.class);
         level.update(modifiable, 1);
         verify(bubble, times(1)).update(any(), anyInt());
         verify(wall, times(1)).update(any(), anyInt());
         verify(projectile, times(1)).update(any(), anyInt());
         verify(pickup, times(1)).update(any(), anyInt());
-        assertTrue(level.getTime() == 1);
     }
 
     /**
@@ -123,7 +126,6 @@ public class LevelTest {
      */
     @Test
     public void testUpdate2() throws SlickException {
-        Level level = new Level(walls, projectiles, pickups, bubbles, 2, 1);
         Modifiable modifiable = mock(Modifiable.class);
         AbstractWall mockedWall = mock(AbstractWall.class);
         level.toAdd(mockedWall);
@@ -146,7 +148,6 @@ public class LevelTest {
      */
     @Test
     public void testUpdate3() throws SlickException {
-        Level level = new Level(walls, projectiles, pickups, bubbles, 3, 1);
         Modifiable modifiable = mock(Modifiable.class);
         AbstractWall mockedWall = mock(AbstractWall.class);
         level.toAdd(mockedWall);
@@ -171,6 +172,19 @@ public class LevelTest {
         assertFalse(pickups.contains(mockedPickup));
         assertFalse(projectiles.contains(mockedProjectile));
     }
+    
+    @Test
+    public void testUpdateShopSlowActive() throws SlickException {
+        Modifiable modifiable = mock(Modifiable.class);
+        level.setShopSlow(true);
+        for (AbstractBubble bubble : bubbles) {
+            assertFalse(bubble.isSlow());
+        }
+        level.update(modifiable, 1);
+        for (AbstractBubble bubble : bubbles) {
+            verify(bubble).setSlow(true);
+        }
+    }
 
     /**
      * Test to check the splitAllBubbles method for level.
@@ -178,7 +192,6 @@ public class LevelTest {
      */
     @Test
     public void testSplitAllBubbles1() throws SlickException {
-        Level level = new Level(walls, projectiles, pickups, bubbles, 3, 1);
         AbstractBubble mockedBubble = mock(AbstractBubble.class);
         bubbles.add(mockedBubble);
         level.splitAllBubbles(bubbles, true);
@@ -191,7 +204,6 @@ public class LevelTest {
      */
     @Test
     public void testSplitAllBubbles2() throws SlickException {
-        Level level = new Level(walls, projectiles, pickups, bubbles, 3, 1);
         AbstractBubble mockedBubble = mock(AbstractBubble.class);
         bubbles.add(mockedBubble);
         level.splitAllBubbles(bubbles, false);
@@ -204,11 +216,39 @@ public class LevelTest {
      */
     @Test
     public void testSplitAllBubbles3() throws SlickException {
-        Level level = new Level(walls, projectiles, pickups, bubbles, 3, 1);
         AbstractBubble mockedBubble = mock(AbstractBubble.class);
         bubbles.add(mockedBubble);
         when(mockedBubble.getImage()).thenReturn(null);
         level.splitAllBubbles(bubbles, false);
         verify(mockedBubble, times(1)).getNext();
+    }
+    
+    @Test
+    public void testGetSetMaxTime() {
+        assertEquals(3, level.getMaxTime());
+        level.setMaxTime(34);
+        assertEquals(34, level.getMaxTime());
+    }
+    
+    @Test
+    public void render() throws SlickException {
+        GameContainer mockedContainer = Mockito.mock(GameContainer.class);
+        Graphics mockedGraphics  = Mockito.mock(Graphics.class);
+        Mockito.when(mockedImage.getWidth()).thenReturn(1);
+        Mockito.when(mockedImage.getHeight()).thenReturn(1);
+        level.render(mockedContainer, mockedGraphics);
+        
+        for(AbstractGameObject gameObject : bubbles) {
+            Mockito.verify(gameObject).render(mockedContainer, mockedGraphics);
+        }
+        for(AbstractGameObject gameObject : walls) {
+            Mockito.verify(gameObject).render(mockedContainer, mockedGraphics);
+        }
+        for(AbstractGameObject gameObject : bubbles) {
+            Mockito.verify(gameObject).render(mockedContainer, mockedGraphics);
+        }
+        for(AbstractGameObject gameObject : pickups) {
+            Mockito.verify(gameObject).render(mockedContainer, mockedGraphics);
+        }
     }
 }

--- a/src/test/java/nl/tudelft/model/pickups/utility/FreezeUtilityTest.java
+++ b/src/test/java/nl/tudelft/model/pickups/utility/FreezeUtilityTest.java
@@ -16,6 +16,7 @@ import nl.tudelft.semgroup4.Modifiable;
 import nl.tudelft.semgroup4.resources.ResourcesWrapper;
 
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
 
@@ -38,8 +39,7 @@ public class FreezeUtilityTest {
         ResourcesWrapper mockedResources = mock(ResourcesWrapper.class);
         FreezeUtility utility = new FreezeUtility(mockedResources, 0, 0);
         
-        Level level = new Level(new LinkedList<>(), new LinkedList<>(), new LinkedList<>(), 
-                new LinkedList<>(), 0, 0);
+        Level level = Mockito.mock(Level.class);
         
         assertFalse(utility.isActive());
         
@@ -58,8 +58,7 @@ public class FreezeUtilityTest {
         LinkedList<AbstractBubble> bubbles = new LinkedList<>();
         bubbles.add(bubble);
         
-        final Level level = new Level(new LinkedList<>(), new LinkedList<>(), new LinkedList<>(), 
-                bubbles, 0, 0);
+        final Level level = Mockito.mock(Level.class);;
         
         assertEquals(0, utility.getFreezeCounter());
         
@@ -72,7 +71,6 @@ public class FreezeUtilityTest {
         utility.update(mockedContainer, 0);
         
         assertEquals(1, utility.getFreezeCounter());
-        assertTrue(bubbles.get(0).isFrozen());
     }
     
     @Test
@@ -85,8 +83,7 @@ public class FreezeUtilityTest {
         LinkedList<AbstractBubble> bubbles = new LinkedList<>();
         bubbles.add(bubble);
         
-        Level level = new Level(new LinkedList<>(), new LinkedList<>(), new LinkedList<>(), 
-                bubbles, 0, 0);
+        Level level = Mockito.mock(Level.class);;
         
         utility.activate(level);
         
@@ -99,6 +96,5 @@ public class FreezeUtilityTest {
         
         assertEquals(300, utility.getFreezeCounter());
         assertTrue(utility.willBeRemoved());
-        assertFalse(bubbles.get(0).isFrozen());
     }
 }

--- a/src/test/java/nl/tudelft/model/pickups/utility/SlowUtilityTest.java
+++ b/src/test/java/nl/tudelft/model/pickups/utility/SlowUtilityTest.java
@@ -6,16 +6,12 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.LinkedList;
-
 import nl.tudelft.model.Level;
-import nl.tudelft.model.bubble.AbstractBubble;
-import nl.tudelft.model.bubble.Bubble6;
-import nl.tudelft.model.bubble.Bubble6Factory;
 import nl.tudelft.semgroup4.Modifiable;
 import nl.tudelft.semgroup4.resources.ResourcesWrapper;
 
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
 
@@ -38,8 +34,7 @@ public class SlowUtilityTest {
         ResourcesWrapper mockedResources = mock(ResourcesWrapper.class);
         SlowUtility utility = new SlowUtility(mockedResources, 0, 0);
         
-        Level level = new Level(new LinkedList<>(), new LinkedList<>(), new LinkedList<>(), 
-                new LinkedList<>(), 0, 0);
+        Level level = Mockito.mock(Level.class);
         
         assertFalse(utility.isActive());
         
@@ -53,13 +48,8 @@ public class SlowUtilityTest {
     public void testUpdate1() throws SlickException {
         ResourcesWrapper mockedResources = mock(ResourcesWrapper.class);
         SlowUtility utility = new SlowUtility(mockedResources, 0, 0);
-
-        AbstractBubble bubble = new Bubble6Factory(mockedResources).createBubble();
-        LinkedList<AbstractBubble> bubbles = new LinkedList<>();
-        bubbles.add(bubble);
         
-        final Level level = new Level(new LinkedList<>(), new LinkedList<>(), new LinkedList<>(), 
-                bubbles, 0, 0);
+        final Level level = Mockito.mock(Level.class);
         
         assertEquals(0, utility.getSlowCounter());
         
@@ -72,7 +62,6 @@ public class SlowUtilityTest {
         utility.update(mockedContainer, 0);
         
         assertEquals(1, utility.getSlowCounter());
-        assertTrue(bubbles.get(0).isSlow());
     }
     
     @Test
@@ -80,13 +69,7 @@ public class SlowUtilityTest {
         ResourcesWrapper mockedResources = mock(ResourcesWrapper.class);
         SlowUtility utility = new SlowUtility(mockedResources, 0, 0);
         
-        AbstractBubble bubble = new Bubble6Factory(mockedResources).createBubble();
-        bubble.setSlow(true);
-        LinkedList<AbstractBubble> bubbles = new LinkedList<>();
-        bubbles.add(bubble);
-        
-        Level level = new Level(new LinkedList<>(), new LinkedList<>(), new LinkedList<>(), 
-                bubbles, 0, 0);
+        Level level = Mockito.mock(Level.class);
         
         utility.activate(level);
         
@@ -99,6 +82,5 @@ public class SlowUtilityTest {
         
         assertEquals(300, utility.getSlowCounter());
         assertTrue(utility.willBeRemoved());
-        assertFalse(bubbles.get(0).isSlow());
     }
 }

--- a/src/test/java/nl/tudelft/model/pickups/utility/TimeUtilityTest.java
+++ b/src/test/java/nl/tudelft/model/pickups/utility/TimeUtilityTest.java
@@ -6,49 +6,62 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.LinkedList;
-
 import nl.tudelft.model.Level;
 import nl.tudelft.semgroup4.resources.ResourcesWrapper;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.newdawn.slick.Image;
 
 public class TimeUtilityTest {
-    
-    @Test
-    public void testConstructor() {
-        ResourcesWrapper mockedResources = mock(ResourcesWrapper.class);
+
+    private ResourcesWrapper mockedResources;
+    private TimeUtility utility;
+
+    /**
+     * Sets up all mocks.
+     */
+    @Before
+    public void setUp() {
+        mockedResources = mock(ResourcesWrapper.class);
         Image mockedImg = mock(Image.class);
         when(mockedResources.getPickupUtilityTime()).thenReturn(mockedImg);
-        TimeUtility utility = new TimeUtility(mockedResources, 0, 0);
-        
+        utility = new TimeUtility(mockedResources, 0, 0);
+    }
+
+    @Test
+    public void testConstructor() {
         assertEquals(mockedResources.getPickupUtilityTime(), utility.getImage());
         assertEquals(0.0f, utility.getLocX(), 0.0f);
         assertEquals(0.0f, utility.getLocY(), 0.0f);
     }
-    
+
     @Test
-    public void testActivate1() {
-        ResourcesWrapper mockedResources = mock(ResourcesWrapper.class);
-        TimeUtility utility = new TimeUtility(mockedResources, 0, 0);
-        
-        Level level = new Level(new LinkedList<>(), new LinkedList<>(), new LinkedList<>(), 
-                new LinkedList<>(), 50000, 0);
+    public void testActivateMaxTimeRemaining() {
+        final int maxTime = 50000;
+        Level level = Mockito.mock(Level.class);
+        Mockito.when(level.getTime()).thenReturn(maxTime);
+        Mockito.when(level.getMaxTime()).thenReturn(maxTime);
+
+        assertFalse(utility.isActive());
+
+        utility.activate(level);
+
+        assertTrue(utility.isActive());
+        Mockito.verify(level).setTime(maxTime);
+    }
+
+    @Test
+    public void testActivateLessThanMaxTimeRemaining() {
+        Level level = Mockito.mock(Level.class);
+        Mockito.when(level.getTime()).thenReturn(0);
+        Mockito.when(level.getMaxTime()).thenReturn(50000);
         
         assertFalse(utility.isActive());
-        assertEquals(50000, level.getTime());
         
         utility.activate(level);
-        
-        assertTrue(utility.isActive());
-        assertEquals(50000, level.getTime());
-        
-        level.setTime(20000);
-        
-        TimeUtility utility2 = new TimeUtility(mockedResources, 0, 0);
-        utility2.activate(level);
-        
-        assertEquals(40000, level.getTime());
+
+        Mockito.verify(level).setTime(20000);
     }
 }


### PR DESCRIPTION
Adds tests for the render method of Level.

This required setting the backGroundImage in the constructor, so that it can be mocked.

Because some Pickup tests did not use mocking to test their interaction with level, those broke and I fixed them by correctly mocking and verifying the calls made to the mocked Level object.

< testing, interface