### PR TITLE
Prevent Tests from resetting custom keybinds

### DIFF
--- a/src/main/java/nl/tudelft/semgroup4/util/KeyBindHelper.java
+++ b/src/main/java/nl/tudelft/semgroup4/util/KeyBindHelper.java
@@ -114,8 +114,8 @@ public class KeyBindHelper {
      * Updates the Settings to the defaults as specified in the DEFAULTS file.
      * 
      * <p>
-     * Overwrites any custom keybindings that were specified in the FILENAME file with their
-     * default values.
+     * Does not overwrite any custom keybindings that were specified in the FILENAME file. To
+     * achieve this, a separate {@link KeyBindHelper#save()} call must be made.
      * </p>
      * 
      * @throws IOException
@@ -125,7 +125,5 @@ public class KeyBindHelper {
         File defaultFile = new File(DEFAULTS);
         JSONObject json = JSONParser.loadJSON(defaultFile);
         updateSettings(json);
-        File saveFile = new File(FILENAME);
-        JSONParser.save(json, saveFile);
     }
 }


### PR DESCRIPTION
On each launch the custom settings were reset because of tests on the setDefaults method.

The setDefaults method specification is now changed to not directly save the settings, but only overwrite the Settings in runtime.

This fixes #203.

< bug