### PR TITLE
Add test previously impossible

### DIFF
--- a/src/test/java/nl/tudelft/view/StartScreenStateTest.java
+++ b/src/test/java/nl/tudelft/view/StartScreenStateTest.java
@@ -236,6 +236,18 @@ public class StartScreenStateTest {
     }
 
     @Test
+    public void testUpdateOptionsButtonHover() throws SlickException {
+        state.init(mockedContainer, mockedSBG);
+        Mockito.when(mockedMouseOverArea.isMouseOver()).thenReturn(true);
+        GameState mockedNewState = Mockito.mock(GameState.class);
+        Mockito.when(mockedSBG.getState(States.OptionsState)).thenReturn(mockedNewState);
+        state.setInput(mockedInput);
+
+        state.updateOptionsButton(mockedContainer, mockedSBG);
+        Mockito.verify(mockedSBG).enterState(States.OptionsState);
+    }
+
+    @Test
     public void testUpdateExitButtonHover() throws SlickException {
         state.init(mockedContainer, mockedSBG);
         Mockito.when(mockedMouseOverArea.isMouseOver()).thenReturn(true);


### PR DESCRIPTION
With the correct implementation of setInput this test no longer
mysteriously crashes.

This is the last test needed to bring the StartScreenState to 100% coverage.

< testing